### PR TITLE
Feature/deb 14991 header scroll fix

### DIFF
--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -59,8 +59,10 @@
     }
 
     function handleKeyDown(e, args) {
+      var column;	
       if (e.which == 32) {
-        if (_grid.getColumns()[args.cell].id === _options.columnId) {
+        column = _grid.getColumns()[args.cell];
+        if (column && column.id === _options.columnId) {
           // if editing, try to commit
           if (!_grid.getEditorLock().isActive() || _grid.getEditorLock().commitCurrentEdit()) {
             toggleRowSelection(args.row);

--- a/plugins/slick.checkboxselectcolumn.js
+++ b/plugins/slick.checkboxselectcolumn.js
@@ -1,3 +1,13 @@
+/**
+ * NOTES:
+ *     NTW change log:
+ *     1) Fixed exception: Uncaught TypeError: Cannot read property 'id' of undefined slick.checkboxselectcolumn.js
+ *        This happens when some columns are remove from the grid and then spacebar is pressed in the grid. 
+ *        Checkbox-plugin uses spacebar to toggle the checkbox state. Grid passes the last active cell as argument to the handleKeyDown(), 
+ *        which might no longer be a valid cell. Ideally, Grid should update its active-cell if the columns are reset. 
+ *        But , anyway, this fix, in handleKeyDown(), will safeguard us from the exception.
+ */
+ 
 (function ($) {
   // register namespace
   $.extend(true, window, {

--- a/plugins/slick.rowmovemanager.js
+++ b/plugins/slick.rowmovemanager.js
@@ -1,3 +1,14 @@
+/**
+ * NOTES:
+ *     This is a third party plugin. We were using the version that came with slick-grid.
+ *     https://github.com/mleibman/SlickGrid/blob/master/plugins/slick.rowmovemanager.js
+ *     Origin: https://github.com/reebalazs/SlickGrid-plugin-rowmovemanager/blob/master/plugins/slick.rowmovemanager.js
+ *
+ *     NTW change log:
+ *     1) Updated "handleDragInit()" to fire "slick.rowmovemanager.mousedown" event in lieu of mousedown event because
+ *        "handleDragInit" stops the propagation of the mousedown event, this broke our widget level mousedown handling.
+ */
+ 
 (function ($) {
   // register namespace
   $.extend(true, window, {
@@ -32,8 +43,12 @@
     }
 
     function handleDragInit(e, dd) {
+      var $canvas = $(_canvas);
       // prevent the grid from cancelling drag'n'drop by default
       e.stopImmediatePropagation();
+      // since event propagation is killed, fire "slick.rowmovemanager.mousedown"
+      // event, in case someone out there is interested in handling it.
+      $canvas.trigger("slick.rowmovemanager.mousedown");
     }
 
     function handleDragStart(e, dd) {

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -785,11 +785,7 @@
           if ((groupingInfos.length && (eitherIsNonData = (item.__nonDataRow) || (r.__nonDataRow)) &&
               item.__group !== r.__group ||
               item.__group && !item.equals(r))
-              || (eitherIsNonData &&
-              // no good way to compare totals since they are arbitrary DTOs
-              // deep object comparison is pretty expensive
-              // always considering them 'dirty' seems easier for the time being
-              (item.__groupTotals || r.__groupTotals))
+              || (eitherIsNonData && (!options.compareTotalMethod || !options.compareTotalMethod(item.totals, r.totals)))
               || item[idProperty] != r[idProperty]
               || (updated && updated[item[idProperty]])
               ) {

--- a/slick.dataview.js
+++ b/slick.dataview.js
@@ -596,8 +596,10 @@
 
         if (!g.collapsed) {
           rows = g.groups ? flattenGroupedRows(g.groups, level + 1) : g.rows;
-          for (var j = 0, jj = rows.length; j < jj; j++) {
-            groupedRows[gl++] = rows[j];
+          if (!options.rollupSingleChildGroup || (rows && rows.length > 1)) {
+            for (var j = 0, jj = rows.length; j < jj; j++) {
+              groupedRows[gl++] = rows[j];
+            }
           }
         }
 

--- a/slick.grid.css
+++ b/slick.grid.css
@@ -86,12 +86,19 @@ classes should alter those!
   width: 100%;
 }
 
-.slick-cell, .slick-headerrow-column {
+.slick-headerrow-column {
   position: absolute;
+  overflow: hidden;
+}
+
+.slick-cell {
+  display: inline-block;
+}
+
+.slick-cell, .slick-headerrow-column {
   border: 1px solid transparent;
   border-right: 1px dotted silver;
   border-bottom-color: silver;
-  overflow: hidden;
   -o-text-overflow: ellipsis;
   text-overflow: ellipsis;
   vertical-align: middle;

--- a/slick.grid.css
+++ b/slick.grid.css
@@ -77,6 +77,7 @@ classes should alter those!
 
 .grid-canvas {
   position: relative;
+  overflow: hidden;
   outline: 0;
 }
 
@@ -84,14 +85,25 @@ classes should alter those!
   position: absolute;
   border: 0px;
   width: 100%;
+  white-space: nowrap;
+}
+
+.slick-headerrow-column {
+  position: absolute;
+  overflow: hidden;
+}
+
+.slick-cell {
+  display: inline-block;
 }
 
 .slick-cell, .slick-headerrow-column {
-  position: absolute;
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
   border: 1px solid transparent;
   border-right: 1px dotted silver;
   border-bottom-color: silver;
-  overflow: hidden;
   -o-text-overflow: ellipsis;
   text-overflow: ellipsis;
   vertical-align: middle;

--- a/slick.grid.css
+++ b/slick.grid.css
@@ -86,19 +86,12 @@ classes should alter those!
   width: 100%;
 }
 
-.slick-headerrow-column {
-  position: absolute;
-  overflow: hidden;
-}
-
-.slick-cell {
-  display: inline-block;
-}
-
 .slick-cell, .slick-headerrow-column {
+  position: absolute;
   border: 1px solid transparent;
   border-right: 1px dotted silver;
   border-bottom-color: silver;
+  overflow: hidden;
   -o-text-overflow: ellipsis;
   text-overflow: ellipsis;
   vertical-align: middle;

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1058,11 +1058,13 @@ if (typeof Slick === "undefined") {
     }
 
     function applyColumnWidths() {
-      var w, rule;
+      var x = 0, w, rule;
       for (var i = 0; i < columns.length; i++) {
         w = columns[i].width;
 
-        $('.' + uid + ' .l' + i).css('width',  w - absoluteColumnMinWidth + 'px');
+        $('.' + uid + ' .l' + i).css('left', x);
+        $('.' + uid + ' .r' + i).css('right', (canvasWidth - x - w));
+        x += columns[i].width;
       }
     }
 
@@ -1353,7 +1355,7 @@ if (typeof Slick === "undefined") {
 
       stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px; height:" + options.rowHeight + "px;'>");
 
-      var colspan, m, columnData, w, cellStyle;
+      var colspan, m, columnData, w, x = 0, cellStyle;
       for (var i = 0, ii = columns.length; i < ii; i++) {
         m = columns[i];
         if (metadata && metadata.columns) {
@@ -1366,7 +1368,8 @@ if (typeof Slick === "undefined") {
         for (var j = i; j <= i + colspan - 1; j++) {
           w += columns[j].width;
         }
-        cellStyle = 'width:' + (w-absoluteColumnMinWidth) + 'px;height:' + rowHeight + 'px';
+        cellStyle = 'left:' + x + 'px; right:' + (canvasWidth - x - w) + 'px; height:' + rowHeight + 'px;';
+        x += w;
 
         // Do not render cells outside of the viewport.
         if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1049,7 +1049,7 @@ if (typeof Slick === "undefined") {
       var h;
       for (var i = 0, headers = $headers.children(), ii = headers.length; i < ii; i++) {
         h = $(headers[i]);
-        if (h.outerWidth() !== columns[i].width - headerColumnWidthDiff) {
+        if (columns[i] && h.outerWidth() !== columns[i].width - headerColumnWidthDiff) {
           h.outerWidth(columns[i].width - headerColumnWidthDiff);
         }
       }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1058,13 +1058,11 @@ if (typeof Slick === "undefined") {
     }
 
     function applyColumnWidths() {
-      var x = 0, w, rule;
+      var w, rule;
       for (var i = 0; i < columns.length; i++) {
         w = columns[i].width;
 
-        $('.' + uid + ' .l' + i).css('left', x);
-        $('.' + uid + ' .r' + i).css('right', (canvasWidth - x - w));
-        x += columns[i].width;
+        $('.' + uid + ' .l' + i).css('width',  w - absoluteColumnMinWidth + 'px');
       }
     }
 
@@ -1355,7 +1353,7 @@ if (typeof Slick === "undefined") {
 
       stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px; height:" + options.rowHeight + "px;'>");
 
-      var colspan, m, columnData, w, x = 0, cellStyle;
+      var colspan, m, columnData, w, cellStyle;
       for (var i = 0, ii = columns.length; i < ii; i++) {
         m = columns[i];
         if (metadata && metadata.columns) {
@@ -1368,8 +1366,7 @@ if (typeof Slick === "undefined") {
         for (var j = i; j <= i + colspan - 1; j++) {
           w += columns[j].width;
         }
-        cellStyle = 'left:' + x + 'px; right:' + (canvasWidth - x - w) + 'px; height:' + rowHeight + 'px;';
-        x += w;
+        cellStyle = 'width:' + (w-absoluteColumnMinWidth) + 'px;height:' + rowHeight + 'px';
 
         // Do not render cells outside of the viewport.
         if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1679,7 +1679,9 @@ if (typeof Slick === "undefined") {
           while (cacheEntry.cellRenderQueue.length) {
             var columnIdx = cacheEntry.cellRenderQueue.pop();
             cacheEntry.cellNodesByColumnIdx[columnIdx] = lastChild;
-            lastChild = lastChild.previousSibling;
+            if (lastChild !== null) {
+                lastChild = lastChild.previousSibling;
+            }
           }
         }
       }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -545,6 +545,7 @@ if (typeof Slick === "undefined") {
             });
           }
         });
+      var prevLeftScroll = $headerScroller.scrollLeft();
       $headers.empty();
       $headers.width(getHeadersWidth());
 
@@ -606,6 +607,7 @@ if (typeof Slick === "undefined") {
       if (options.enableColumnReorder) {
         setupColumnReorder();
       }
+      $headerScroller.scrollLeft(prevLeftScroll);
     }
 
     function setupColumnSort() {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1586,7 +1586,7 @@ if (typeof Slick === "undefined") {
       }
 
       var oldH = h;
-      th = Math.max(options.rowHeight * numberOfRows, viewportH - scrollbarDimensions.height);
+      th = Math.max(options.rowHeight * numberOfRows, viewportH - (viewportHasHScroll ? scrollbarDimensions.height : 0));
       if (th < maxSupportedCssHeight) {
         // just one page
         h = ph = th;

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1556,7 +1556,11 @@ if (typeof Slick === "undefined") {
       handleScroll();
       // Since the width has changed, force the render() to reevaluate virtually rendered cells.
       lastRenderedScrollLeft = -1;
-      render();
+      //render();
+      if (h_render) {
+        clearTimeout(h_render);
+      }
+      h_render = setTimeout(render, 200);
     }
 
     function updateRowCount() {
@@ -1576,7 +1580,7 @@ if (typeof Slick === "undefined") {
       // this helps avoid redundant calls to .removeRow() when the size of the data decreased by thousands of rows
       var l = dataLengthIncludingAddNew - 1;
       for (var i in rowsCache) {
-        if (i >= l) {
+        if (i > l) {
           removeRowFromCache(i);
         }
       }
@@ -1650,13 +1654,13 @@ if (typeof Slick === "undefined") {
 
       if (vScrollDir == -1) {
         range.top -= buffer;
-        range.bottom += minBuffer;
+        range.bottom += buffer;
       } else if (vScrollDir == 1) {
-        range.top -= minBuffer;
+        range.top -= buffer;
         range.bottom += buffer;
       } else {
-        range.top -= minBuffer;
-        range.bottom += minBuffer;
+        range.top -= buffer;
+        range.bottom += buffer;
       }
 
       range.top = Math.max(0, range.top);
@@ -1679,7 +1683,7 @@ if (typeof Slick === "undefined") {
           while (cacheEntry.cellRenderQueue.length) {
             var columnIdx = cacheEntry.cellRenderQueue.pop();
             cacheEntry.cellNodesByColumnIdx[columnIdx] = lastChild;
-            if (lastChild !== null) {
+            if (lastChild !== null){
                 lastChild = lastChild.previousSibling;
             }
           }
@@ -1965,13 +1969,14 @@ if (typeof Slick === "undefined") {
 
         if (Math.abs(lastRenderedScrollTop - scrollTop) > 20 ||
             Math.abs(lastRenderedScrollLeft - scrollLeft) > 20) {
-          if (options.forceSyncScrolling || (
+          /*if (options.forceSyncScrolling || (
               Math.abs(lastRenderedScrollTop - scrollTop) < viewportH &&
               Math.abs(lastRenderedScrollLeft - scrollLeft) < viewportW)) {
             render();
           } else {
             h_render = setTimeout(render, 50);
-          }
+          }*/
+          h_render = setTimeout(render, 200);
 
           trigger(self.onViewportChanged, {});
         }

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1071,6 +1071,7 @@ if (typeof Slick === "undefined") {
           }
           cells.css('width', w - absoluteColumnMinWidth + 'px');
         }
+      }
     }
 
     function setSortColumn(columnId, ascending) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -125,7 +125,6 @@ if (typeof Slick === "undefined") {
     var $topPanel;
     var $viewport;
     var $canvas;
-    var $style;
     var $boundAncestors;
     var stylesheet, columnCssRulesL, columnCssRulesR;
     var viewportH, viewportW;
@@ -241,13 +240,13 @@ if (typeof Slick === "undefined") {
       $headers.width(getHeadersWidth());
 
       $headerRowScroller = $("<div class='slick-headerrow ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
-      $headerRow = $("<div class='slick-headerrow-columns' />").appendTo($headerRowScroller);
+      $headerRow = $("<div class='slick-headerrow-columns' style='height:" + options.headerRowHeight + "px'/>").appendTo($headerRowScroller);
       $headerRowSpacer = $("<div style='display:block;height:1px;position:absolute;top:0;left:0;'></div>")
           .css("width", getCanvasWidth() + scrollbarDimensions.width + "px")
           .appendTo($headerRowScroller);
 
       $topPanelScroller = $("<div class='slick-top-panel-scroller ui-state-default' style='overflow:hidden;position:relative;' />").appendTo($container);
-      $topPanel = $("<div class='slick-top-panel' style='width:10000px' />").appendTo($topPanelScroller);
+      $topPanel = $("<div class='slick-top-panel' style='width:10000px; height:" + options.topPanelHeight + "px'/>").appendTo($topPanelScroller);
 
       if (!options.showTopPanel) {
         $topPanelScroller.hide();
@@ -297,7 +296,6 @@ if (typeof Slick === "undefined") {
         updateColumnCaches();
         createColumnHeaders();
         setupColumnSort();
-        createCssRules();
         resizeCanvas();
         bindAncestorScrollEvents();
 
@@ -566,6 +564,7 @@ if (typeof Slick === "undefined") {
             .attr("title", m.toolTip || "")
             .data("column", m)
             .addClass(m.headerCssClass || "")
+            .css('left', 1000)
             .appendTo($headers);
 
         if (options.enableColumnReorder || m.sortable) {
@@ -917,79 +916,6 @@ if (typeof Slick === "undefined") {
       absoluteColumnMinWidth = Math.max(headerColumnWidthDiff, cellWidthDiff);
     }
 
-    function createCssRules() {
-      $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
-      var rowHeight = (options.rowHeight - cellHeightDiff);
-      if ($style[0].styleSheet) { // IE
-        $style[0].styleSheet.cssText = "";
-      } else {
-        $style[0].appendChild(document.createTextNode(""));
-      }
-        var sheet =  $style[0].sheet;
-        var index = 0;
-        addCSSRule(sheet,"." + uid + " .slick-header-column", "left: 1000px;",index++);
-        addCSSRule(sheet,"." + uid + " .slick-top-panel", "height:" + options.topPanelHeight + "px;",index++);
-        addCSSRule(sheet,"." + uid + " .slick-headerrow-columns", "height:" + options.headerRowHeight + "px;",index++);
-        addCSSRule(sheet,"." + uid + " .slick-cell", "height:" + rowHeight + "px;",index++);
-        addCSSRule(sheet,"." + uid + " .slick-row", "height:" + options.rowHeight + "px;",index++);
-
-        for (var i = 0; i < columns.length; i++) {
-            addCSSRule(sheet,"." + uid + " .l" + i , "",index++);
-            addCSSRule(sheet,"." + uid + " .r" + i, "",index++);
-          }
-    }
-
-    function addCSSRule(sheet, selector, rules, index) {
-        if(sheet.insertRule) {
-            sheet.insertRule(selector + "{" + rules + "}", index);
-        }
-        else {
-            sheet.addRule(selector, rules, index);
-        }
-    }
-
-    function getColumnCssRules(idx) {
-      if (!stylesheet) {
-        var sheets = document.styleSheets;
-        for (var i = 0; i < sheets.length; i++) {
-          if ((sheets[i].ownerNode || sheets[i].owningElement) == $style[0]) {
-            stylesheet = sheets[i];
-            break;
-          }
-        }
-
-        if (!stylesheet) {
-          throw new Error("Cannot find stylesheet.");
-        }
-
-        // find and cache column CSS rules
-        columnCssRulesL = [];
-        columnCssRulesR = [];
-        var cssRules = (stylesheet.cssRules || stylesheet.rules);
-        var matches, columnIdx;
-        for (var i = 0; i < cssRules.length; i++) {
-          var selector = cssRules[i].selectorText;
-          if (matches = /\.l\d+/.exec(selector)) {
-            columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
-            columnCssRulesL[columnIdx] = cssRules[i];
-          } else if (matches = /\.r\d+/.exec(selector)) {
-            columnIdx = parseInt(matches[0].substr(2, matches[0].length - 2), 10);
-            columnCssRulesR[columnIdx] = cssRules[i];
-          }
-        }
-      }
-
-      return {
-        "left": columnCssRulesL[idx],
-        "right": columnCssRulesR[idx]
-      };
-    }
-
-    function removeCssRules() {
-      $style.remove();
-      stylesheet = null;
-    }
-
     function destroy() {
       getEditorLock().cancelCurrentEdit();
 
@@ -1006,8 +932,6 @@ if (typeof Slick === "undefined") {
 
       unbindAncestorScrollEvents();
       $container.unbind(".slickgrid");
-      removeCssRules();
-
       $canvas.unbind("draginit dragstart dragend drag");
       $container.empty().removeClass(uid);
     }
@@ -1132,10 +1056,8 @@ if (typeof Slick === "undefined") {
       for (var i = 0; i < columns.length; i++) {
         w = columns[i].width;
 
-        rule = getColumnCssRules(i);
-        rule.left.style.left = x + "px";
-        rule.right.style.right = (canvasWidth - x - w) + "px";
-
+        $('.' + uid + ' .l' + i).css('left', x);
+        $('.' + uid + ' .r' + i).css('right', (canvasWidth - x - w));
         x += columns[i].width;
       }
     }
@@ -1229,8 +1151,6 @@ if (typeof Slick === "undefined") {
       if (initialized) {
         invalidateAllRows();
         createColumnHeaders();
-        removeCssRules();
-        createCssRules();
         resizeCanvas();
         applyColumnWidths();
         handleScroll();
@@ -1421,24 +1341,29 @@ if (typeof Slick === "undefined") {
       }
 
       var metadata = data.getItemMetadata && data.getItemMetadata(row,d );
+      var rowHeight = (options.rowHeight - cellHeightDiff);
 
       if (metadata && metadata.cssClasses) {
         rowCss += " " + metadata.cssClasses;
       }
 
-      stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px'>");
+      stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px; height:" + options.rowHeight + "px;'>");
 
-      var colspan, m, columnData;
+      var colspan, m, columnData, w, x = 0, cellStyle;
       for (var i = 0, ii = columns.length; i < ii; i++) {
         m = columns[i];
-        colspan = 1;
         if (metadata && metadata.columns) {
           columnData = metadata.columns[m.id] || metadata.columns[i];
-          colspan = (columnData && columnData.colspan) || 1;
-          if (colspan === "*") {
-            colspan = ii - i;
-          }
         }
+
+        colspan = getColspan (row, i);
+
+        w = 0;
+        for (var j = i; j <= i + colspan - 1; j++) {
+          w += columns[j].width;
+        }
+        cellStyle = 'left:' + x + 'px; right:' + (canvasWidth - x - w) + 'px; height:' + rowHeight + 'px;';
+        x += w;
 
         // Do not render cells outside of the viewport.
         if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
@@ -1447,7 +1372,7 @@ if (typeof Slick === "undefined") {
             break;
           }
 
-          appendCellHtml(stringArray, row, i, colspan, columnData, d);
+          appendCellHtml(stringArray, row, i, colspan, columnData, d, cellStyle);
         }
 
         if (colspan > 1) {
@@ -1458,7 +1383,7 @@ if (typeof Slick === "undefined") {
       stringArray.push("</div>");
     }
 
-    function appendCellHtml(stringArray, row, cell, colspan, columMetadata, item) {
+    function appendCellHtml(stringArray, row, cell, colspan, columMetadata, item, cellStyle) {
       var m = columns[cell];
       var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
           (m.cssClass ? " " + m.cssClass : "");
@@ -1477,7 +1402,7 @@ if (typeof Slick === "undefined") {
         }
       }
 
-      stringArray.push("<div class='" + cellCss + "'>");
+      stringArray.push("<div class='" + cellCss + "' style='" + cellStyle + "'>");
 
       // if there is a corresponding row (if not, this is the Add New row or this data hasn't been loaded yet)
       if (item) {
@@ -1803,6 +1728,8 @@ if (typeof Slick === "undefined") {
       var cellsAdded;
       var totalCellsAdded = 0;
       var colspan;
+      var w, x, j, cellStyle, columnData;
+      var rowHeight = (options.rowHeight - cellHeightDiff);
 
       for (var row = range.top, btm = range.bottom; row <= btm; row++) {
         cacheEntry = rowsCache[row];
@@ -1823,6 +1750,7 @@ if (typeof Slick === "undefined") {
         var metadata = data.getItemMetadata && data.getItemMetadata(row, d);
         metadata = metadata && metadata.columns;
 
+        x = 0; // reset to 0 before looping the columns
         // TODO:  shorten this loop (index? heuristics? binary search?)
         for (var i = 0, ii = columns.length; i < ii; i++) {
           // Cells to the right are outside the range.
@@ -1832,21 +1760,30 @@ if (typeof Slick === "undefined") {
 
           // Already rendered.
           if ((colspan = cacheEntry.cellColSpans[i]) != null) {
+            // Before continuing the loop, adjust the x value to make it ready for the next iteration.
+            for (j = i; j <= i + colspan - 1; j++) {
+              x += columns[j].width;
+            }
             i += (colspan > 1 ? colspan - 1 : 0);
             continue;
           }
 
-          colspan = 1;
+          // Retrieving the colspan from metadata again (not from cacheEntry)
+          colspan = getColspan (row, i);
           if (metadata) {
-            var columnData = metadata[columns[i].id] || metadata[i];
-            colspan = (columnData && columnData.colspan) || 1;
-            if (colspan === "*") {
-              colspan = ii - i;
-            }
+            columnData = metadata[columns[i].id] || metadata.columns[i];
           }
 
+          w = 0;
+          for (j = i; j <= i + colspan - 1; j++) {
+            w += columns[j].width;
+          }
+
+          cellStyle = 'left:' + x +'px; right:' + (canvasWidth - x - w) + 'px; height:' + rowHeight + 'px;';
+          x += w;
+
           if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
-            appendCellHtml(stringArray, row, i, colspan, columnData, d);
+            appendCellHtml(stringArray, row, i, colspan, columnData, d, cellStyle);
             cellsAdded++;
           }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -559,7 +559,7 @@ if (typeof Slick === "undefined") {
 
         var header = $("<div class='ui-state-default slick-header-column' />")
             .html("<span class='slick-column-name'>" + m.name + "</span>")
-            .width(m.width - headerColumnWidthDiff)
+            .outerWidth(m.width - headerColumnWidthDiff)
             .attr("id", "" + uid + m.id)
             .attr("title", m.toolTip || "")
             .data("column", m)

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1771,7 +1771,7 @@ if (typeof Slick === "undefined") {
           // Retrieving the colspan from metadata again (not from cacheEntry)
           colspan = getColspan (row, i);
           if (metadata) {
-            columnData = metadata[columns[i].id] || metadata.columns[i];
+            columnData = metadata[columns[i].id] || metadata[i];
           }
 
           w = 0;

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -193,11 +193,15 @@ if (typeof Slick === "undefined") {
 
       // calculate these only once and share between grid instances
       maxSupportedCssHeight = maxSupportedCssHeight || getMaxSupportedCssHeight();
-      scrollbarDimensions = scrollbarDimensions || measureScrollbar();
 
       options = $.extend({}, defaults, options);
       validateAndEnforceOptions();
       columnDefaults.width = options.defaultColumnWidth;
+      if(options.scrollbarDimensions){
+        scrollbarDimensions = options.scrollbarDimensions
+      }else{
+        scrollbarDimensions = scrollbarDimensions || measureScrollbar();
+      }
 
       columnsById = {};
       for (var i = 0; i < columns.length; i++) {

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -1420,7 +1420,7 @@ if (typeof Slick === "undefined") {
         rowCss += " " + options.addNewRowCssClass;
       }
 
-      var metadata = data.getItemMetadata && data.getItemMetadata(row);
+      var metadata = data.getItemMetadata && data.getItemMetadata(row,d );
 
       if (metadata && metadata.cssClasses) {
         rowCss += " " + metadata.cssClasses;
@@ -1428,12 +1428,12 @@ if (typeof Slick === "undefined") {
 
       stringArray.push("<div class='ui-widget-content " + rowCss + "' style='top:" + getRowTop(row) + "px'>");
 
-      var colspan, m;
+      var colspan, m, columnData;
       for (var i = 0, ii = columns.length; i < ii; i++) {
         m = columns[i];
         colspan = 1;
         if (metadata && metadata.columns) {
-          var columnData = metadata.columns[m.id] || metadata.columns[i];
+          columnData = metadata.columns[m.id] || metadata.columns[i];
           colspan = (columnData && columnData.colspan) || 1;
           if (colspan === "*") {
             colspan = ii - i;
@@ -1447,7 +1447,7 @@ if (typeof Slick === "undefined") {
             break;
           }
 
-          appendCellHtml(stringArray, row, i, colspan, d);
+          appendCellHtml(stringArray, row, i, colspan, columnData, d);
         }
 
         if (colspan > 1) {
@@ -1458,12 +1458,16 @@ if (typeof Slick === "undefined") {
       stringArray.push("</div>");
     }
 
-    function appendCellHtml(stringArray, row, cell, colspan, item) {
+    function appendCellHtml(stringArray, row, cell, colspan, columMetadata, item) {
       var m = columns[cell];
       var cellCss = "slick-cell l" + cell + " r" + Math.min(columns.length - 1, cell + colspan - 1) +
           (m.cssClass ? " " + m.cssClass : "");
       if (row === activeRow && cell === activeCell) {
         cellCss += (" active");
+      }
+
+      if (columMetadata && columMetadata.cssClass) {
+          cellCss += " " + columMetadata.cssClass;
       }
 
       // TODO:  merge them together in the setter
@@ -1814,10 +1818,10 @@ if (typeof Slick === "undefined") {
         // Render missing cells.
         cellsAdded = 0;
 
-        var metadata = data.getItemMetadata && data.getItemMetadata(row);
-        metadata = metadata && metadata.columns;
-
         var d = getDataItem(row);
+
+        var metadata = data.getItemMetadata && data.getItemMetadata(row, d);
+        metadata = metadata && metadata.columns;
 
         // TODO:  shorten this loop (index? heuristics? binary search?)
         for (var i = 0, ii = columns.length; i < ii; i++) {
@@ -1842,7 +1846,7 @@ if (typeof Slick === "undefined") {
           }
 
           if (columnPosRight[Math.min(ii - 1, i + colspan - 1)] > range.leftPx) {
-            appendCellHtml(stringArray, row, i, colspan, d);
+            appendCellHtml(stringArray, row, i, colspan, columnData, d);
             cellsAdded++;
           }
 

--- a/slick.grid.js
+++ b/slick.grid.js
@@ -920,24 +920,32 @@ if (typeof Slick === "undefined") {
     function createCssRules() {
       $style = $("<style type='text/css' rel='stylesheet' />").appendTo($("head"));
       var rowHeight = (options.rowHeight - cellHeightDiff);
-      var rules = [
-        "." + uid + " .slick-header-column { left: 1000px; }",
-        "." + uid + " .slick-top-panel { height:" + options.topPanelHeight + "px; }",
-        "." + uid + " .slick-headerrow-columns { height:" + options.headerRowHeight + "px; }",
-        "." + uid + " .slick-cell { height:" + rowHeight + "px; }",
-        "." + uid + " .slick-row { height:" + options.rowHeight + "px; }"
-      ];
-
-      for (var i = 0; i < columns.length; i++) {
-        rules.push("." + uid + " .l" + i + " { }");
-        rules.push("." + uid + " .r" + i + " { }");
-      }
-
       if ($style[0].styleSheet) { // IE
-        $style[0].styleSheet.cssText = rules.join(" ");
+        $style[0].styleSheet.cssText = "";
       } else {
-        $style[0].appendChild(document.createTextNode(rules.join(" ")));
+        $style[0].appendChild(document.createTextNode(""));
       }
+        var sheet =  $style[0].sheet;
+        var index = 0;
+        addCSSRule(sheet,"." + uid + " .slick-header-column", "left: 1000px;",index++);
+        addCSSRule(sheet,"." + uid + " .slick-top-panel", "height:" + options.topPanelHeight + "px;",index++);
+        addCSSRule(sheet,"." + uid + " .slick-headerrow-columns", "height:" + options.headerRowHeight + "px;",index++);
+        addCSSRule(sheet,"." + uid + " .slick-cell", "height:" + rowHeight + "px;",index++);
+        addCSSRule(sheet,"." + uid + " .slick-row", "height:" + options.rowHeight + "px;",index++);
+
+        for (var i = 0; i < columns.length; i++) {
+            addCSSRule(sheet,"." + uid + " .l" + i , "",index++);
+            addCSSRule(sheet,"." + uid + " .r" + i, "",index++);
+          }
+    }
+
+    function addCSSRule(sheet, selector, rules, index) {
+        if(sheet.insertRule) {
+            sheet.insertRule(selector + "{" + rules + "}", index);
+        }
+        else {
+            sheet.addRule(selector, rules, index);
+        }
     }
 
     function getColumnCssRules(idx) {


### PR DESCRIPTION
@sergiopereiraTT @efurmantt  Please review.  Thank you.

The problem was when using Firefox (maybe IE too), if you reorder the slickgrid columns when the HScroll bar is not to the leftmost, the data would appear corrupt, because the header row is scrolled to the leftmost.  It happens in Firefox, but in Chrome, it can also happen if a breakpoint is set at certain place in the code.  I cannot determine what is unique in Firefox that makes this consistently happen in Firefox.  However, there's a simple fix by remembering the scrollleft position of the header row and restore it after headers are reconstructed.  With that simple change, it works in both Firefox and Chrome now.